### PR TITLE
Enable address and undefined behavior sanitizers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,20 @@ bin/dtb-debug.o: include/dtb/dtb.h src/dtb.c src/utils.h src/debug.h
 bin/utils-debug.o: src/utils.h src/utils.c src/debug.h
 	$(CC) -c src/utils.c -o bin/utils-debug.o -ggdb $(CFLAGS)
 
+bin/dtb-san.o: include/dtb/dtb.h src/dtb.c src/utils.h src/debug.h
+	$(CC) -c src/dtb.c -o bin/dtb-debug.o -ggdb $(CFLAGS) -fsanitize=address,undefined
 
-bin/test_qemu-virt: bin/dtb-debug.o bin/utils-debug.o test/test_qemu-virt.c test/test.h include/dtb/dtb.h
-	$(CC) -c test/test_qemu-virt.c -o bin/test_qemu-virt.o $(CFLAGS) -ggdb
-	$(CC) -o bin/test_qemu-virt bin/dtb-debug.o bin/utils-debug.o bin/test_qemu-virt.o -ggdb
+bin/utils-san.o: src/utils.h src/utils.c src/debug.h
+	$(CC) -c src/utils.c -o bin/utils-debug.o -ggdb $(CFLAGS) -fsanitize=address,undefined
 
-bin/test_utils: bin/utils-debug.o test/test_utils.c test/test.h
-	$(CC) -c test/test_utils.c -o bin/test_utils.o -Isrc $(CFLAGS) -ggdb
-	$(CC) -o bin/test_utils bin/utils-debug.o bin/test_utils.o -ggdb
+
+bin/test_qemu-virt: bin/dtb-san.o bin/utils-san.o test/test_qemu-virt.c test/test.h include/dtb/dtb.h
+	$(CC) -c test/test_qemu-virt.c -o bin/test_qemu-virt.o $(CFLAGS) -ggdb -fsanitize=address,undefined
+	$(CC) -o bin/test_qemu-virt bin/dtb-debug.o bin/utils-debug.o bin/test_qemu-virt.o -ggdb -fsanitize=address,undefined
+
+bin/test_utils: bin/utils-san.o test/test_utils.c test/test.h
+	$(CC) -c test/test_utils.c -o bin/test_utils.o -Isrc $(CFLAGS) -ggdb -fsanitize=address,undefined
+	$(CC) -o bin/test_utils bin/utils-debug.o bin/test_utils.o -ggdb -fsanitize=address,undefined
 
 test: bin/test_utils bin/test_qemu-virt
 	@ bin/test_utils


### PR DESCRIPTION
Enable address and undefined behavior sanitizers to help catch more errors on the tests.

Closes #6 