### PR TITLE
Remove macro iterators and replace with `dtb_next_*` style iterators

### DIFF
--- a/include/dtb/dtb.h
+++ b/include/dtb/dtb.h
@@ -62,35 +62,6 @@ dtb_property dtb_next_property(dtb_property prop);
 
 dtb_node dtb_next_sibling(dtb_node node);
 
-// NOTE: assumes that address-cells and size-cells props come before any other prop
-#define dtb_foreach_property(dtb, node, x) { \
-    char *__strings = (char *)dtb + DTB_BYTESWAP32(dtb->off_dt_strings); \
-    uint32_t *__prop = node + 1; \
-    while (1) { \
-        if (*__prop == DTB_NOP) { \
-            __prop++;\
-        } else if (*__prop == DTB_PROP) {\
-            uint32_t __attribute__((unused)) address_cells = 2; \
-            uint32_t __attribute__((unused)) size_cells = 1; \
-            uint32_t proplen = DTB_BYTESWAP32(*(__prop + 1));\
-            uint32_t __stroff = DTB_BYTESWAP32(*(__prop + 2));\
-            char *propname = __strings + __stroff; \
-            uint32_t __attribute__((unused)) *prop = __prop + 3; \
-            if (strcmp(propname, "#address-cells") == 0) { \
-                address_cells = *prop; \
-            } else if (strcmp(propname, "#size-cells") == 0) { \
-                size_cells = *__prop + 3; \
-            } else { \
-                x \
-            } \
-            __prop += proplen / sizeof(uint32_t) + 2; \
-        } else if (*__prop == DTB_END || *__prop == DTB_BEGIN_NODE || *__prop == DTB_END_NODE) { \
-            break;\
-        }\
-        __prop++; \
-    } \
-}
-
 #define dtb_foreach_rsvmap_entry(dtb, x) {                                      \
         uint8_t *__dtb_ptr = (uint8_t *)dtb;                                    \
         uint8_t *__entry_ptr = __dtb_ptr + DTB_BYTESWAP32(dtb->off_mem_rsvmap); \

--- a/include/dtb/dtb.h
+++ b/include/dtb/dtb.h
@@ -56,6 +56,8 @@ dtb_node dtb_find(dtb *devicetree, const char *path);
 
 char *dtb_property_name(dtb *devicetree, dtb_node node);
 
+#define dtb_foreach_property(node, name) for (dtb_property name = dtb_first_property(node); name != NULL; name = dtb_next_property(name))
+
 dtb_property dtb_first_property(dtb_property prop);
 
 dtb_property dtb_next_property(dtb_property prop);

--- a/include/dtb/dtb.h
+++ b/include/dtb/dtb.h
@@ -64,14 +64,10 @@ dtb_property dtb_next_property(dtb_property prop);
 
 dtb_node dtb_next_sibling(dtb_node node);
 
-#define dtb_foreach_rsvmap_entry(dtb, x) {                                      \
-        uint8_t *__dtb_ptr = (uint8_t *)dtb;                                    \
-        uint8_t *__entry_ptr = __dtb_ptr + DTB_BYTESWAP32(dtb->off_mem_rsvmap); \
-        dtb_rsvmap_entry *entry = (dtb_rsvmap_entry *)__entry_ptr;              \
-        while (!(entry->address == 0 && entry->size == 0)) {                    \
-            x                                                                   \
-        }                                                                       \
-    }
+dtb_rsvmap_entry *dtb_first_rsvmap_entry(dtb *devicetree);
 
+dtb_rsvmap_entry *dtb_next_rsvmap_entry(dtb_rsvmap_entry *entry);
+
+#define dtb_foreach_rsvmap_entry(dtb, entry) for (dtb_rsvmap_entry *entry = dtb_first_rsvmap_entry(dtb); entry != NULL; entry = dtb_next_rsvmap_entry(entry))
 
 #endif // _DTB_H

--- a/include/dtb/dtb.h
+++ b/include/dtb/dtb.h
@@ -62,7 +62,11 @@ dtb_property dtb_first_property(dtb_property prop);
 
 dtb_property dtb_next_property(dtb_property prop);
 
+dtb_node dtb_first_child(dtb_node node);
+
 dtb_node dtb_next_sibling(dtb_node node);
+
+#define dtb_foreach_child(node, name) for (dtb_node name = dtb_first_child(node); name != NULL; name = dtb_next_sibling(name))
 
 dtb_rsvmap_entry *dtb_first_rsvmap_entry(dtb *devicetree);
 

--- a/include/dtb/dtb.h
+++ b/include/dtb/dtb.h
@@ -41,6 +41,7 @@ typedef struct __attribute__((packed))
 } dtb_rsvmap_entry;
 
 typedef uint32_t* dtb_node;
+typedef uint32_t* dtb_property;
 
 /**
  * @brief Create a device tree object from a pointer.
@@ -52,6 +53,12 @@ dtb *dtb_fromptr(void *ptr);
 dtb_node dtb_find(dtb *devicetree, const char *path);
 
 #define dtb_node_name(node) (char *)((uint32_t *)node+1)
+
+char *dtb_property_name(dtb *devicetree, dtb_node node);
+
+dtb_property dtb_first_property(dtb_property prop);
+
+dtb_property dtb_next_property(dtb_property prop);
 
 dtb_node dtb_next_sibling(dtb_node node);
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -10,11 +10,13 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <inttypes.h>
+#include <assert.h>
 
 #define DEBUG_PRINT(...) printf(__VA_ARGS__)
 
 #else
 #define DEBUG_PRINT(...)
+#define assert(x)
 #endif
 
 #endif // _DEBUG_H

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,7 +1,10 @@
 #ifndef _DEBUG_H
 #define _DEBUG_H
 
-#if 0
+#define DEBUG_CONFIG_PRINTS  0
+#define DEBUG_CONFIG_ASSERTS 0
+
+#if DEBUG_CONFIG_PRINTS
 #include <stdio.h>
 #include <stdint.h>
 #include <unistd.h>
@@ -10,12 +13,16 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <inttypes.h>
-#include <assert.h>
 
 #define DEBUG_PRINT(...) printf(__VA_ARGS__)
-
 #else
 #define DEBUG_PRINT(...)
+#endif
+
+#if DEBUG_CONFIG_ASSERTS
+#include <assert.h>
+#include <stdbool.h>
+#else
 #define assert(x)
 #endif
 

--- a/src/dtb.c
+++ b/src/dtb.c
@@ -132,6 +132,23 @@ dtb_property dtb_next_property(dtb_property prop)
     return token;
 }
 
+dtb_node dtb_first_child(dtb_node node)
+{
+    assert(*node == DTB_BEGIN_NODE);
+
+    uint32_t *token = next_token(node);
+    while (*token != DTB_BEGIN_NODE) {
+        if (*token == DTB_END || *token == DTB_END_NODE) {
+            return NULL;
+        }
+
+        token = next_token(token);
+    }
+
+    assert(*token == DTB_BEGIN_NODE);
+    return token;
+}
+
 dtb_node dtb_next_sibling(dtb_node node)
 {
     int depth = 0;

--- a/src/dtb.c
+++ b/src/dtb.c
@@ -176,3 +176,26 @@ dtb_node dtb_next_sibling(dtb_node node)
 
     return node;
 }
+
+dtb_rsvmap_entry *dtb_first_rsvmap_entry(dtb *devicetree)
+{
+    uint8_t *dtb_ptr = (uint8_t *)devicetree;
+    dtb_rsvmap_entry *entry = (dtb_rsvmap_entry *)(dtb_ptr + DTB_BYTESWAP32(devicetree->off_mem_rsvmap));
+
+    if (entry->address == 0 && entry->size == 0) {
+        return NULL;
+    }
+
+    return entry;
+}
+
+dtb_rsvmap_entry *dtb_next_rsvmap_entry(dtb_rsvmap_entry *entry)
+{
+    entry++;
+
+    if (entry->address == 0 && entry->size == 0) {
+        return NULL;
+    }
+
+    return entry;
+}

--- a/src/dtb.c
+++ b/src/dtb.c
@@ -97,6 +97,41 @@ dtb_node dtb_find(dtb *devicetree, const char *path)
     return NULL;
 }
 
+char *dtb_property_name(dtb *devicetree, dtb_node node)
+{
+    char *strings = (char *)devicetree + DTB_BYTESWAP32(devicetree->off_dt_strings);
+    uint32_t stroff = DTB_BYTESWAP32(*(node + 2));
+    return strings + stroff;
+}
+
+dtb_property dtb_first_property(dtb_node node)
+{
+    uint32_t *token = next_token(node);
+    while (*token != DTB_PROP) {
+        if (*token == DTB_END || *token == DTB_BEGIN_NODE || *token == DTB_END_NODE) {
+            return NULL;
+        }
+
+        token = next_token(token);
+    }
+
+    return token;
+}
+
+dtb_property dtb_next_property(dtb_property prop)
+{
+    uint32_t *token = next_token(prop);
+    while (*token != DTB_PROP) {
+        if (*token == DTB_END || *token == DTB_BEGIN_NODE || *token == DTB_END_NODE) {
+            return NULL;
+        }
+
+        token = next_token(token);
+    }
+
+    return token;
+}
+
 dtb_node dtb_next_sibling(dtb_node node)
 {
     int depth = 0;

--- a/src/utils.c
+++ b/src/utils.c
@@ -39,6 +39,7 @@ uint32_t *next_token(uint32_t *token)
 
         tokenchar += (uint64_t)tokenchar % 4;
         token = (uint32_t *)tokenchar;
+        token++;
 
         assert(*token != FDT_END);
     } else if (*token == DTB_END_NODE) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -24,3 +24,43 @@ int strcmp_nodename(const char *pathpart, const char *nodename)
 
     return 1;
 }
+
+uint32_t *next_token(uint32_t *token)
+{
+    assert((uint64_t)token % 4 == 0);
+
+    if (*token == DTB_BEGIN_NODE) {
+        token++;
+
+        char *tokenchar = (char *)token;
+        while (*tokenchar != '\0') {
+            tokenchar++;
+        }
+
+        tokenchar += (uint64_t)tokenchar % 4;
+        token = (uint32_t *)tokenchar;
+
+        assert(*token != FDT_END);
+    } else if (*token == DTB_END_NODE) {
+        token++;
+
+        assert(*token != DTB_PROP);
+    } else if (*token == DTB_PROP) {
+        uint32_t len = DTB_BYTESWAP32(*(token + 1));
+        if (len % sizeof(uint32_t) == 0) {
+            token += len / sizeof(uint32_t) + 3;
+        } else {
+            uint32_t len_rounding = 4 - (len % 4);
+            token += (len + len_rounding) / sizeof(uint32_t) + 3;
+        }
+
+        assert(*token != DTB_END);
+    } else if (*token == DTB_NOP) {
+        token++;
+    } else {
+        assert(false);
+    }
+
+    assert((uint64_t)token % 4 == 0);
+    return token;
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -30,6 +30,7 @@ uint32_t *next_token(uint32_t *token)
     assert((uint64_t)token % 4 == 0);
 
     if (*token == DTB_BEGIN_NODE) {
+        DEBUG_PRINT("%p: DTB_BEGIN_NODE %s\n", (void *)token, (char *)(token + 1));
         token++;
 
         char *tokenchar = (char *)token;
@@ -41,13 +42,15 @@ uint32_t *next_token(uint32_t *token)
         token = (uint32_t *)tokenchar;
         token++;
 
-        assert(*token != FDT_END);
+        assert(*token != DTB_END);
     } else if (*token == DTB_END_NODE) {
+        DEBUG_PRINT("%p: DTB_END_NODE\n", (void *)token);
         token++;
 
         assert(*token != DTB_PROP);
     } else if (*token == DTB_PROP) {
         uint32_t len = DTB_BYTESWAP32(*(token + 1));
+        DEBUG_PRINT("%p: PROP %" PRIu32 "\n", (void *)token, len);
         if (len % sizeof(uint32_t) == 0) {
             token += len / sizeof(uint32_t) + 3;
         } else {
@@ -57,6 +60,7 @@ uint32_t *next_token(uint32_t *token)
 
         assert(*token != DTB_END);
     } else if (*token == DTB_NOP) {
+        DEBUG_PRINT("%p: DTB_NOP %s\n", (void *)token, (char *)(token + 1));
         token++;
     } else {
         assert(false);

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,4 +5,6 @@
 
 int strcmp_nodename(const char *pathpart, const char *nodename);
 
+uint32_t *next_token(uint32_t *token);
+
 #endif // _UTILS_

--- a/test/test_qemu-virt.c
+++ b/test/test_qemu-virt.c
@@ -10,9 +10,9 @@ int main(int argc, char **argv)
     print_test_result("qemu-virt: dtb_fromptr", devicetree != NULL);
 
     bool has_rsvmap_entries = false;
-    dtb_foreach_rsvmap_entry(devicetree, {
+    dtb_foreach_rsvmap_entry(devicetree, entry) {
         has_rsvmap_entries = true;
-    });
+    }
     print_test_result("qemu-virt: dtb_foreach_rsvmap_entry", has_rsvmap_entries == false);
 
     dtb_node null_node = dtb_find(devicetree, "/not/exist");

--- a/test/test_qemu-virt.c
+++ b/test/test_qemu-virt.c
@@ -23,15 +23,21 @@ int main(int argc, char **argv)
 
     bool found_compatible = false;
     bool found_model = false;
+    bool found_addr_cells = false;
+    bool found_size_cells = false;
     dtb_foreach_property(root_node, prop) {
         char *propname = dtb_property_name(devicetree, prop);
         if (strcmp(propname, "compatible") == 0) {
             found_compatible = true;
         } else if (strcmp(propname, "model") == 0) {
             found_model = true;
+        } else if (strcmp(propname, "#address-cells") == 0) {
+            found_addr_cells = true;
+        } else if (strcmp(propname, "#size-cells") == 0) {
+            found_size_cells = true;
         }
     }
-    bool ok = found_compatible == true && found_model == true;
+    bool ok = found_compatible && found_model && found_addr_cells && found_size_cells;
     print_test_result("qemu-virt: dtb_foreach_property '/'", ok);
 
     bool found_pmu = false;
@@ -87,4 +93,5 @@ int main(int argc, char **argv)
     dtb_node test_node = dtb_next_sibling(serial_node);
     char *test_node_str = dtb_node_name(test_node);
     print_test_result("qemu-virt: dtb_next_sibling '/soc/serial' -> '/soc/test'", strcmp(test_node_str, "test@100000") == 0);
+
 }

--- a/test/test_qemu-virt.c
+++ b/test/test_qemu-virt.c
@@ -23,7 +23,7 @@ int main(int argc, char **argv)
 
     bool found_compatible = false;
     bool found_model = false;
-    for (dtb_property prop = dtb_first_property(root_node); prop != NULL; prop = dtb_next_property(prop)) {
+    dtb_foreach_property(root_node, prop) {
         char *propname = dtb_property_name(devicetree, prop);
         if (strcmp(propname, "compatible") == 0) {
             found_compatible = true;

--- a/test/test_qemu-virt.c
+++ b/test/test_qemu-virt.c
@@ -23,13 +23,14 @@ int main(int argc, char **argv)
 
     bool found_compatible = false;
     bool found_model = false;
-    dtb_foreach_property(devicetree, root_node, {
+    for (dtb_property prop = dtb_first_property(root_node); prop != NULL; prop = dtb_next_property(prop)) {
+        char *propname = dtb_property_name(devicetree, prop);
         if (strcmp(propname, "compatible") == 0) {
             found_compatible = true;
         } else if (strcmp(propname, "model") == 0) {
             found_model = true;
         }
-    });
+    }
     bool ok = found_compatible == true && found_model == true;
     print_test_result("qemu-virt: dtb_foreach_property '/'", ok);
 

--- a/test/test_qemu-virt.c
+++ b/test/test_qemu-virt.c
@@ -34,6 +34,44 @@ int main(int argc, char **argv)
     bool ok = found_compatible == true && found_model == true;
     print_test_result("qemu-virt: dtb_foreach_property '/'", ok);
 
+    bool found_pmu = false;
+    bool found_fw_cfg = false;
+    bool found_flash = false;
+    bool found_chosen = false;
+    bool found_poweroff = false;
+    bool found_reboot = false;
+    bool found_platform_bus = false;
+    bool found_memory = false;
+    bool found_cpus = false;
+    bool found_soc = false;
+    dtb_foreach_child(root_node, child) {
+        char *childname = dtb_node_name(child);
+        if (strcmp(childname, "pmu") == 0) {
+            found_pmu = true;
+        } else if (strcmp(childname, "fw-cfg@10100000") == 0) {
+            found_fw_cfg = true;
+        } else if (strcmp(childname, "flash@20000000") == 0) {
+            found_flash = true;
+        } else if (strcmp(childname, "chosen") == 0) {
+            found_chosen = true;
+        } else if (strcmp(childname, "poweroff") == 0) {
+            found_poweroff = true;
+        } else if (strcmp(childname, "reboot") == 0) {
+            found_reboot = true;
+        } else if (strcmp(childname, "platform-bus@4000000") == 0) {
+            found_platform_bus = true;
+        } else if (strcmp(childname, "memory@80000000") == 0) {
+            found_memory = true;
+        } else if (strcmp(childname, "cpus") == 0) {
+            found_cpus = true;
+        } else if (strcmp(childname, "soc") == 0) {
+            found_soc = true;
+        }
+    }
+    ok = found_pmu && found_fw_cfg && found_flash && found_chosen && found_poweroff && found_reboot
+        && found_platform_bus && found_memory && found_cpus && found_soc;
+    print_test_result("qemu-virt: dtb_foreach_child '/'", ok);
+
     dtb_node memory_node = dtb_find(devicetree, "/memory");
     ok = memory_node != NULL && strcmp(dtb_node_name(memory_node), "memory@80000000") == 0;
     print_test_result("qemu-virt: dtb_find '/memory'", ok);


### PR DESCRIPTION
Doing and maintaining macro based iterators is a pain in the ass to say the least. Instead the next scheme is going to be used in order to iterate on properties and child nodes:

1. Use a `dtb_first_*` function to retrieve the first element (first property or child node).
2. Use a `dtb_next_*` function to retrieve the next element
3. Repeat until the `dtb_next_*` returns NULL, signifying there is no other element left.